### PR TITLE
Fix invalid use of `sum` reduction on type Real

### DIFF
--- a/Components/HeatExchangers/PlateHEXvle2vle_L3_2ph_ntu.mo
+++ b/Components/HeatExchangers/PlateHEXvle2vle_L3_2ph_ntu.mo
@@ -268,7 +268,7 @@ model PlateHEXvle2vle_L3_2ph_ntu "VLE 2 VLE | L2 | PlateHEX NTU"
 
   Summary summary(outline(
       showExpertSummary=showExpertSummary,
-      Q_flow=sum(flow_a.heat.Q_flow),
+      Q_flow=flow_a.heat.Q_flow,
       Delta_T_in=flow_a.summary.inlet.T - flow_b.summary.inlet.T,
       Delta_T_out=flow_a.summary.outlet.T - flow_b.summary.outlet.T)) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},


### PR DESCRIPTION
Reduction functions operate on array expressions, see https://specification.modelica.org/maint/3.5/arrays.html#modelica:sum-of-array

The variable `flow_a.heat.Q_flow` is of type Real. Thus the use of `sum` is not Modelica compliant.